### PR TITLE
New MetaIdentityManager to .me

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "serverless-webpack": "^4.2.0",
     "slack-webhook": "^1.0.0",
     "truffle-contract": "^3.0.0",
-    "uport-identity": "^2.0.0",
+    "uport-identity": "^2.0.1",
     "web3": "^0.20.3",
     "webpack": "^3.10.0",
     "webpack-node-externals": "^1.6.0"

--- a/src/lib/identityManagerMgr.js
+++ b/src/lib/identityManagerMgr.js
@@ -33,7 +33,7 @@ class IdentityManagerMgr {
         break;
       case 'MetaIdentityManager':
         idMgrs = this.metaIdentityManagers
-        idMgrArtifact = MetaIdentityManager.v2
+        idMgrArtifact = MetaIdentityManager.v3
         break;
       default:
         throw('invalid managerType')
@@ -184,7 +184,7 @@ class IdentityManagerMgr {
 
   async decodeLogs(txReceipt){
     if(!txReceipt) throw('no txReceipt')
-    const idMgrArtifact =  MetaIdentityManager.v2 //TODO: need to fix this
+    const idMgrArtifact =  MetaIdentityManager.v3 //TODO: need to fix this
 
     let eventAbi = idMgrArtifact.abi.filter((o) => { return o.name === 'LogIdentityCreated' })[0]
     let log = txReceipt.logs[0] //I hope is always the first one


### PR DESCRIPTION
I've tested unnu on .space with the new MetaIdentityManager and it worked for both creation and recovery. Should be ready to go live on .me 