### PR TITLE
Lower gas limit when creating identities.

### DIFF
--- a/src/lib/identityManagerMgr.js
+++ b/src/lib/identityManagerMgr.js
@@ -85,7 +85,7 @@ class IdentityManagerMgr {
     let from = this.ethereumMgr.getAddress(); //TODO: read from provider
     let txOptions = {
       from: from,
-      gas: 3000000,
+      gas: 400000,
       gasPrice: await this.ethereumMgr.getGasPrice(blockchain),
       nonce: await this.ethereumMgr.getNonce(from, blockchain)
     };


### PR DESCRIPTION
An identity creation takes `301363` gas: https://rinkeby.etherscan.io/tx/0x3776098212f40bebd5e87750fd75c27b2561730db0d7b63772e5c3efedfc3a5b
So I lowered the gasLimit to `400000`.